### PR TITLE
translations to latin languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,19 +47,19 @@ Open [http://127.0.0.1:3001/api/namer](http://127.0.0.1:3001/api/namer) file in 
 ### Installation
 
 ```bash
-npm install
+yarn install
 ```
 
 ### Development
 
 BSB Development
 ```bash
-npm start:dev
+yarn start:dev
 ```
 
 Webpack Development
 ```bash
-npm run build
+yarn run build
 ```
 
 Open [index.html](client/public/index.html) file in your browser.

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,5 +1,6 @@
 .merlin
 .bsb.lock
+.log
 lib
 node_modules
 coverage/

--- a/api/src/Constants.re
+++ b/api/src/Constants.re
@@ -1,2 +1,7 @@
 let appPort = 3001;
 let gcloudTranslateApiKey = "AIzaSyASAnHi5hJuApvaoxTOf1yPxaQ4PfiSIHA";
+let latinTranslations = [
+  "en",
+  "fr",
+  "co", /* Corse */
+];

--- a/api/src/Index.re
+++ b/api/src/Index.re
@@ -23,7 +23,7 @@ PromiseMiddleware.from(
     switch (Utils.getDictString(Request.params(request), "term")) {
       | None => Js.Promise.resolve(next(Next.route, resource))
       | Some(term) => Js.Promise.(
-          Namer.asyncNamer(term, "en")
+          Namer.asyncNamer(term)
           |> then_(
             (namings) => Namer.encodeNamingToJson(namings)
               |> (json) => resolve(Response.sendJson(json, resource))


### PR DESCRIPTION
Translate `term` to latin languages

Example:

GET `http://127.0.0.1:3001/api/namer/bonjour`

```json
{
    "term": "bonjour",
    "synonymes": [],
    "translations": [
        {
            "language": "en",
            "translation": "Hello"
        },
        {
            "language": "fr",
            "translation": "bonjour"
        },
        {
            "language": "co",
            "translation": "ciao"
        }
    ],
    "suggestions": []
}
```